### PR TITLE
Use "pactSpecificationVersion" rather than "pactSpecification"

### DIFF
--- a/io/pactNoConsumerSpec.json
+++ b/io/pactNoConsumerSpec.json
@@ -1,0 +1,35 @@
+{
+	"provider": {
+		"name": "provider"
+	},
+	"interactions": [
+		{
+			"provider_state": "some state",
+			"description": "description of the interaction",
+			"request": {
+				"body": {
+					"firstName": "John",
+					"lastName": "Doe"
+				},
+				"headers": {
+					"Content-Type": "application/json"
+				},
+				"method": "POST",
+				"path": "/",
+				"query": "param=xyzmk"
+			},
+			"response": {
+				"body": {
+					"result": true
+				},
+				"headers": {
+					"Content-Type": "application/json"
+				},
+				"status": 201
+			}
+		}
+	],
+	"metaData": {
+		"pactSpecificationVersion": "1.1.0"
+	}
+}

--- a/io/pactNoProviderSpec.json
+++ b/io/pactNoProviderSpec.json
@@ -1,0 +1,37 @@
+{
+	"consumer": {
+		"name": "consumer"
+	},
+	"provider": {
+	},
+	"interactions": [
+		{
+			"provider_state": "some state",
+			"description": "description of the interaction",
+			"request": {
+				"body": {
+					"firstName": "John",
+					"lastName": "Doe"
+				},
+				"headers": {
+					"Content-Type": "application/json"
+				},
+				"method": "POST",
+				"path": "/",
+				"query": "param=xyzmk"
+			},
+			"response": {
+				"body": {
+					"result": true
+				},
+				"headers": {
+					"Content-Type": "application/json"
+				},
+				"status": 201
+			}
+		}
+	],
+	"metaData": {
+		"pactSpecificationVersion": "1.1.0"
+	}
+}

--- a/io/pactWrongSpec.json
+++ b/io/pactWrongSpec.json
@@ -33,6 +33,6 @@
 		}
 	],
 	"metaData": {
-		"pactSpecification": "2.0.0"
+		"pactSpecificationVersion": "2.0.0"
 	}
 }

--- a/io/pact_file.go
+++ b/io/pact_file.go
@@ -9,7 +9,7 @@ import (
 	"github.com/SEEK-Jobs/pact-go/consumer"
 )
 
-const pactSpecification = "1.1.0"
+const pactSpecificationVersion = "1.1.0"
 
 var (
 	errEmptyProvider = errors.New("Pactfile is invalid, provider name should not be empty.")
@@ -21,7 +21,7 @@ type Participant struct {
 }
 
 type metadata struct {
-	PactSpecification string `json:"pactSpecification"`
+	PactSpecificationVersion string `json:"pactSpecificationVersion"`
 }
 
 type PactFile struct {
@@ -36,7 +36,7 @@ func NewPactFile(consumer string, provider string, interactions []*consumer.Inte
 		Consumer:     &Participant{Name: consumer},
 		Provider:     &Participant{Name: provider},
 		Interactions: interactions,
-		Metadata:     &metadata{PactSpecification: pactSpecification},
+		Metadata:     &metadata{PactSpecificationVersion: pactSpecificationVersion},
 	}
 }
 

--- a/io/pact_file.go
+++ b/io/pact_file.go
@@ -12,8 +12,9 @@ import (
 const pactSpecificationVersion = "1.1.0"
 
 var (
-	errEmptyProvider = errors.New("Pactfile is invalid, provider name should not be empty.")
-	errEmptyConsumer = errors.New("Pactfile is invalid, consumer name should not be empty.")
+	errEmptyProvider    = errors.New("Pactfile is invalid, provider name should not be empty.")
+	errEmptyConsumer    = errors.New("Pactfile is invalid, consumer name should not be empty.")
+	errIncompatiblePact = fmt.Errorf("Incompatible pact specification! We only support version %s.", pactSpecificationVersion)
 )
 
 type Participant struct {
@@ -58,5 +59,10 @@ func (p *PactFile) Validate() error {
 	if p.Consumer == nil || p.Consumer.Name == "" {
 		return errEmptyConsumer
 	}
+
+	if p.Metadata.PactSpecificationVersion != pactSpecificationVersion {
+		return errIncompatiblePact
+	}
+
 	return nil
 }

--- a/io/pact_file_reader.go
+++ b/io/pact_file_reader.go
@@ -14,7 +14,7 @@ type pactFileReader struct {
 	filePath string
 }
 
-var errIncompatiblePact = fmt.Errorf("Incompatible pact specification! We only support version %s.", pactSpecification)
+var errIncompatiblePact = fmt.Errorf("Incompatible pact specification! We only support version %s.", pactSpecificationVersion)
 
 func NewPactFileReader(filePath string) PactReader {
 	return &pactFileReader{filePath: filePath}
@@ -31,7 +31,7 @@ func (r *pactFileReader) Read() (f *PactFile, err error) {
 		return nil, err
 	}
 
-	if f.Metadata.PactSpecification != pactSpecification {
+	if f.Metadata.PactSpecificationVersion != pactSpecificationVersion {
 		return nil, errIncompatiblePact
 	}
 	return f, nil

--- a/io/pact_file_reader.go
+++ b/io/pact_file_reader.go
@@ -2,7 +2,6 @@ package io
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 )
 
@@ -13,8 +12,6 @@ type PactReader interface {
 type pactFileReader struct {
 	filePath string
 }
-
-var errIncompatiblePact = fmt.Errorf("Incompatible pact specification! We only support version %s.", pactSpecificationVersion)
 
 func NewPactFileReader(filePath string) PactReader {
 	return &pactFileReader{filePath: filePath}
@@ -29,10 +26,6 @@ func (r *pactFileReader) Read() (f *PactFile, err error) {
 
 	if err = json.Unmarshal(b, f); err != nil {
 		return nil, err
-	}
-
-	if f.Metadata.PactSpecificationVersion != pactSpecificationVersion {
-		return nil, errIncompatiblePact
 	}
 	return f, nil
 }

--- a/io/pact_file_reader_test.go
+++ b/io/pact_file_reader_test.go
@@ -19,14 +19,3 @@ func Test_FileReader_BadFilePath_ShouldReturnError(t *testing.T) {
 		t.Error("expected error")
 	}
 }
-
-func Test_FileReader_InvalidSpec_ShouldReturnError(t *testing.T) {
-	path := "./pactWrongSpec.json"
-	r := NewPactFileReader(path)
-
-	if _, err := r.Read(); err == nil {
-		t.Error("expected not supported pact error")
-	} else if err != errIncompatiblePact {
-		t.Error("got the wrong error")
-	}
-}

--- a/io/pact_file_test.go
+++ b/io/pact_file_test.go
@@ -4,14 +4,40 @@ import "testing"
 
 func Test_Validate_ValidFile(t *testing.T) {
 	path := "../pact_examples/consumer-provider.json"
-	r := NewPactFileReader(path)
+	p := readPactFile(t, path)
 
+	if err := p.Validate(); err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_Validate_MissingProvider(t *testing.T) {
+	path := "./pactNoProviderSpec.json"
+	p := readPactFile(t, path)
+
+	expectError(t, p.Validate(), errEmptyProvider)
+}
+
+func Test_Validate_MissingConsumer(t *testing.T) {
+	path := "./pactNoConsumerSpec.json"
+	p := readPactFile(t, path)
+
+	expectError(t, p.Validate(), errEmptyConsumer)
+}
+
+func readPactFile(t *testing.T, path string) *PactFile {
+	r := NewPactFileReader(path)
 	p, err := r.Read()
 	if err != nil {
 		t.Error(err)
 	}
+	return p
+}
 
-	if err := p.Validate(); err != nil {
-		t.Error(err)
+func expectError(t *testing.T, actual, expected error) {
+	if actual == nil {
+		t.Error("expected an error")
+	} else if actual != expected {
+		t.Error("got %v error, expected %v", actual, expected)
 	}
 }

--- a/io/pact_file_test.go
+++ b/io/pact_file_test.go
@@ -25,6 +25,13 @@ func Test_Validate_MissingConsumer(t *testing.T) {
 	expectError(t, p.Validate(), errEmptyConsumer)
 }
 
+func Test_Validate_InvalidSpec(t *testing.T) {
+	path := "./pactWrongSpec.json"
+	p := readPactFile(t, path)
+
+	expectError(t, p.Validate(), errIncompatiblePact)
+}
+
 func readPactFile(t *testing.T, path string) *PactFile {
 	r := NewPactFileReader(path)
 	p, err := r.Read()
@@ -38,6 +45,6 @@ func expectError(t *testing.T, actual, expected error) {
 	if actual == nil {
 		t.Error("expected an error")
 	} else if actual != expected {
-		t.Error("got %v error, expected %v", actual, expected)
+		t.Errorf("got %q error, expected %q", actual, expected)
 	}
 }

--- a/io/pact_file_test.go
+++ b/io/pact_file_test.go
@@ -1,0 +1,17 @@
+package io
+
+import "testing"
+
+func Test_Validate_ValidFile(t *testing.T) {
+	path := "../pact_examples/consumer-provider.json"
+	r := NewPactFileReader(path)
+
+	p, err := r.Read()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err := p.Validate(); err != nil {
+		t.Error(err)
+	}
+}

--- a/pact_examples/consumer-provider.json
+++ b/pact_examples/consumer-provider.json
@@ -33,6 +33,6 @@
 		}
 	],
 	"metaData": {
-		"pactSpecification": "1.1.0"
+		"pactSpecificationVersion": "1.1.0"
 	}
 }


### PR DESCRIPTION
The [specification](https://github.com/pact-foundation/pact-specification/tree/version-1.1) unfortunately doesn't seem to specify what format the version should be given in, however the de-facto reference
implementation uses `pactSpecificationVersion`
(e.g. https://github.com/realestate-com-au/pact/blob/master/example/zoo-app/spec/pacts/zoo_app-animal_service.json), and this is what is generated by the RSpec code.

Of course, this change would break existing tests which include

    "pactSpecification": "1.1.0"

Happy to update this PR to include code which first looks for `pactSpecificationVersion`, and falls back to `pactSpecification` to preserve compatibility… what do you think?