### PR TITLE
Use net/http's basic auth when communicating with broker

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,6 @@ type VerfierConfig struct {
 }
 
 type PactUriConfig struct {
-	AuthScheme string
-	AuthValue  string
+	Username string
+	Password string
 }

--- a/io/pact_web_reader.go
+++ b/io/pact_web_reader.go
@@ -8,17 +8,17 @@ import (
 )
 
 type pactWebReader struct {
-	url        string
-	authScheme string
-	authVal    string
+	url      string
+	username string
+	password string
 }
 
 func IsWebUri(url string) bool {
 	return strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://")
 }
 
-func NewPactWebReader(url, authScheme, authVal string) PactReader {
-	return &pactWebReader{url: url, authScheme: authScheme, authVal: authVal}
+func NewPactWebReader(url, username, password string) PactReader {
+	return &pactWebReader{url: url, username: username, password: password}
 }
 
 func (p *pactWebReader) Read() (*PactFile, error) {
@@ -28,8 +28,8 @@ func (p *pactWebReader) Read() (*PactFile, error) {
 	}
 
 	req.Header.Add("Accept", "application/json")
-	if p.authScheme != "" && p.authVal != "" {
-		req.Header.Add("Authorisation", fmt.Sprintf("%s %s", p.authScheme, p.authVal))
+	if p.username != "" && p.password != "" {
+		req.SetBasicAuth(p.username, p.password)
 	}
 
 	c := &http.Client{}

--- a/pact_examples/chrome_browser-go_api.json
+++ b/pact_examples/chrome_browser-go_api.json
@@ -40,6 +40,6 @@
 		}
 	],
 	"metaData": {
-		"pactSpecification": "1.1.0"
+		"pactSpecificationVersion": "1.1.0"
 	}
 }

--- a/verifier.go
+++ b/verifier.go
@@ -108,7 +108,7 @@ func (v *pactFileVerfier) Verify() error {
 func (v *pactFileVerfier) getPactFile() (*io.PactFile, error) {
 	var r io.PactReader
 	if io.IsWebUri(v.pactUri) {
-		r = io.NewPactWebReader(v.pactUri, v.pactUriConfig.AuthScheme, v.pactUriConfig.AuthValue)
+		r = io.NewPactWebReader(v.pactUri, v.pactUriConfig.Username, v.pactUriConfig.Password)
 	} else {
 		r = io.NewPactFileReader(v.pactUri)
 	}


### PR DESCRIPTION
Change motivated by:
* code was previously broken, due to use of `Authorisation` instead of `Authorization` header
* logic to generate a basic auth token not exposed in stdlib, hence users would need to roll their own