### PR TITLE
Bugfix: SetBody empty array

### DIFF
--- a/provider/http_content.go
+++ b/provider/http_content.go
@@ -20,9 +20,9 @@ type jsonContent struct {
 }
 
 func (c *jsonContent) GetData() ([]byte, error) {
-	if len(c.data) > 0 {
+	if c.data != nil {
 		return json.Marshal(c.data)
-	} else if len(c.sliceData) > 0 {
+	} else if c.sliceData != nil {
 		return json.Marshal(c.sliceData)
 	} else {
 		return nil, nil

--- a/provider/http_content.go
+++ b/provider/http_content.go
@@ -30,9 +30,9 @@ func (c *jsonContent) GetData() ([]byte, error) {
 }
 
 func (c *jsonContent) GetBody() interface{} {
-	if len(c.data) > 0 {
+	if c.data != nil {
 		return c.data
-	} else if len(c.sliceData) > 0 {
+	} else if c.sliceData != nil {
 		return c.sliceData
 	} else {
 		return nil

--- a/provider/response_test.go
+++ b/provider/response_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func Test_Response_MarshalJSON_BodyShouldBeEmptyArray(t *testing.T) {
+func Test_Response_MarshalJSON_BodyShouldExist(t *testing.T) {
 	header := make(http.Header)
 	header.Add("content-type", "application/json")
 	response := NewJSONResponse(200, header)
@@ -15,6 +15,6 @@ func Test_Response_MarshalJSON_BodyShouldBeEmptyArray(t *testing.T) {
 	result, _ := response.MarshalJSON()
 
 	if !bytes.Contains(result, []byte(`"body"`)) {
-		t.Error(t, "Response should contain body with an empty array.")
+		t.Error(t, "Response should contain body field.")
 	}
 }

--- a/provider/response_test.go
+++ b/provider/response_test.go
@@ -1,0 +1,20 @@
+package provider
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+)
+
+func Test_Response_MarshalJSON_BodyShouldBeEmptyArray(t *testing.T) {
+	header := make(http.Header)
+	header.Add("content-type", "application/json")
+	response := NewJSONResponse(200, header)
+	response.SetBody(`[]`)
+
+	result, _ := response.MarshalJSON()
+
+	if !bytes.Contains(result, []byte(`"body"`)) {
+		t.Error(t, "Response should contain body with an empty array.")
+	}
+}


### PR DESCRIPTION
If a response body is an empty array, it should be serialized to JSON as an empty array as well.